### PR TITLE
Add Unknown functional status to UI

### DIFF
--- a/src/cce-inventory-item-details/inventory-item-details.controller.spec.js
+++ b/src/cce-inventory-item-details/inventory-item-details.controller.spec.js
@@ -195,6 +195,14 @@ describe('InventoryItemDetailsController', function() {
             expect(vm.getFunctionalStatusLabel()).toEqual('cceInventoryItemStatus.unserviceable');
         });
 
+        it('should return the value of cceInventoryItemStatus.unknown for UNKNOWN', function() {
+            vm.inventoryItem = new FacilityProgramInventoryItemDataBuilder()
+                .withFunctionalStatus('UNKNOWN')
+                .build();
+
+            expect(vm.getFunctionalStatusLabel()).toEqual('cceInventoryItemStatus.unknown');
+        });
+
     });
 
 });

--- a/src/cce-inventory-item-status/functional-status.constant.js
+++ b/src/cce-inventory-item-status/functional-status.constant.js
@@ -33,6 +33,7 @@
                 FUNCTIONING: 'FUNCTIONING',
                 AWAITING_REPAIR: 'AWAITING_REPAIR',
                 UNSERVICEABLE: 'UNSERVICEABLE',
+                UNKNOWN: 'UNKNOWN',
                 getLabel: getLabel,
                 getStatuses: getStatuses,
                 getClass: getClass
@@ -40,7 +41,8 @@
             labels = {
                 FUNCTIONING: 'cceInventoryItemStatus.functioning',
                 AWAITING_REPAIR: 'cceInventoryItemStatus.awaitingRepair',
-                UNSERVICEABLE: 'cceInventoryItemStatus.unserviceable'
+                UNSERVICEABLE: 'cceInventoryItemStatus.unserviceable',
+                UNKNOWN: 'cceInventoryItemStatus.unknown'
             };
 
         return FUNCTIONAL_STATUS;

--- a/src/cce-inventory-item-status/messages_en.json
+++ b/src/cce-inventory-item-status/messages_en.json
@@ -6,6 +6,7 @@
     "cceInventoryItemStatus.equipmentFunctionalStatus": "Equipment Functional Status",
     "cceInventoryItemStatus.functionalityStatus": "Functionality Status",
     "cceInventoryItemStatus.awaitingRepair": "Awaiting Repair",
+    "cceInventoryItemStatus.unknown": "Unknown",
     "cceInventoryItemStatus.unserviceable": "Unserviceable",
     "cceInventoryItemStatus.notInUse": "Not in use",
     "cceInventoryItemStatus.decommissioned": "Decommissioned",


### PR DESCRIPTION
Hi, would it possible to add please this functional status? It's required from one of our clients (an OpenFn client)
I have opened the pair PR on openlmis-cce: https://github.com/OpenLMIS/openlmis-cce/pull/18

## Change

Adds new functional status to allow saving CCE Inventory with Unknown status here:
![Screenshot from 2024-11-04 12-53-48](https://github.com/user-attachments/assets/4bb379dd-0505-46c2-b2c4-41df993f4a58)

## Build
Built with:
```
$ docker-compose run cce-ui
# npm install
# grunt clean build
# exit
$ docker build . --tag openlmis-fork/cce-ui
```
Then to use it on the reference-ui:
1. Set the image on the docker-compose.yaml replace `image: openlmis/cce-ui:1.1.5` with `image: openlmis-fork/cce-ui`
2. Build with:
```
$ docker-compose run reference-ui
# /build.sh
# exit
$ docker build . --tag openlmis-fork/reference-ui
```  

## Additional notes
This branch was created from the cce-ui `v1.1.5` tag 